### PR TITLE
Hungarian translation

### DIFF
--- a/data/translations/kdiskmark_hu.ts
+++ b/data/translations/kdiskmark_hu.ts
@@ -1,0 +1,456 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu" sourcelanguage="en">
+<context>
+    <name>About</name>
+    <message>
+        <location filename="../../src/about.ui" line="17"/>
+        <source>About KDiskMark</source>
+        <translation>KDiskMark névjegye</translation>
+    </message>
+    <message>
+        <location filename="../../src/about.ui" line="62"/>
+        <source>Version:</source>
+        <translation>Verzió:</translation>
+    </message>
+    <message>
+        <location filename="../../src/about.ui" line="88"/>
+        <source>License:</source>
+        <translation>Licenc:</translation>
+    </message>
+    <message>
+        <location filename="../../src/about.ui" line="114"/>
+        <source>Country:</source>
+        <translation>Származási hely:</translation>
+    </message>
+    <message>
+        <location filename="../../src/about.ui" line="127"/>
+        <source>Russia</source>
+        <translation>Oroszország</translation>
+    </message>
+    <message>
+        <location filename="../../src/about.ui" line="140"/>
+        <source>Author:</source>
+        <translation>Fejlesztő:</translation>
+    </message>
+    <message>
+        <location filename="../../src/about.ui" line="172"/>
+        <source>E-mail:</source>
+        <translation>Kapcsolat:</translation>
+    </message>
+    <message>
+        <location filename="../../src/about.ui" line="204"/>
+        <source>Flexible I/O Tester:</source>
+        <translation>Flexible I/O Tester:</translation>
+    </message>
+    <message>
+        <location filename="../../src/about.ui" line="230"/>
+        <source>Application Icon:</source>
+        <translation>Grafika:</translation>
+    </message>
+</context>
+<context>
+    <name>Benchmark</name>
+    <message>
+        <location filename="../../src/benchmark.cpp" line="46"/>
+        <source>Preparing...</source>
+        <translation>Felkészülés...</translation>
+    </message>
+    <message>
+        <location filename="../../src/benchmark.cpp" line="287"/>
+        <location filename="../../src/benchmark.cpp" line="302"/>
+        <source>Sequential Read %1/%2</source>
+        <translation>Folyamatos olvasás %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/benchmark.cpp" line="292"/>
+        <location filename="../../src/benchmark.cpp" line="307"/>
+        <source>Sequential Write %1/%2</source>
+        <translation>Folyamatos írás %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/benchmark.cpp" line="297"/>
+        <location filename="../../src/benchmark.cpp" line="312"/>
+        <source>Sequential Mix %1/%2</source>
+        <translation>Folyamatos írás és olvasás %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/benchmark.cpp" line="317"/>
+        <location filename="../../src/benchmark.cpp" line="332"/>
+        <source>Random Read %1/%2</source>
+        <translation>Véletlenszerű olvasás %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/benchmark.cpp" line="322"/>
+        <location filename="../../src/benchmark.cpp" line="337"/>
+        <source>Random Write %1/%2</source>
+        <translation>Véletlenszerű írás %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/benchmark.cpp" line="327"/>
+        <location filename="../../src/benchmark.cpp" line="342"/>
+        <source>Random Mix %1/%2</source>
+        <translation>Véletlenszerű írás és olvasás %1/%2</translation>
+    </message>
+    <message>
+        <location filename="../../src/benchmark.cpp" line="348"/>
+        <source>Interval Time %1/%2 sec</source>
+        <translation>Szünet %1/%2 mp</translation>
+    </message>
+</context>
+<context>
+    <name>MainWindow</name>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="30"/>
+        <location filename="../../src/mainwindow.cpp" line="658"/>
+        <source>All</source>
+        <translation>Átfogó
+mérés</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="177"/>
+        <location filename="../../src/mainwindow.cpp" line="400"/>
+        <source>Read</source>
+        <translation>Olvasás</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="340"/>
+        <location filename="../../src/mainwindow.cpp" line="403"/>
+        <source>Write</source>
+        <translation>Írás</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="503"/>
+        <location filename="../../src/mainwindow.cpp" line="406"/>
+        <source>Mix</source>
+        <translation>Vegyes</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="711"/>
+        <source>Add a directory</source>
+        <translation>Elérési útvonal kiválasztása</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="735"/>
+        <location filename="../../src/mainwindow.cpp" line="319"/>
+        <location filename="../../src/mainwindow.cpp" line="325"/>
+        <source>MB/s</source>
+        <translation>MB/mp</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="740"/>
+        <source>GB/s</source>
+        <translation>GB/mp</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="745"/>
+        <location filename="../../src/mainwindow.cpp" line="329"/>
+        <source>IOPS</source>
+        <translation>IOPS</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="750"/>
+        <location filename="../../src/mainwindow.cpp" line="333"/>
+        <source>μs</source>
+        <translation>μs</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="779"/>
+        <source>File</source>
+        <translation>Fájl</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="787"/>
+        <source>Settings</source>
+        <translation>Beállítások</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="794"/>
+        <source>Profile</source>
+        <translation>Profil</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="805"/>
+        <source>Help</source>
+        <translation>Súgó</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="809"/>
+        <source>Language</source>
+        <translation>Nyelv</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="823"/>
+        <source>About KDiskMark</source>
+        <translation>Névjegy</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="828"/>
+        <source>Queues &amp;&amp; Threads</source>
+        <translation>Sorozatok és szálak</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="833"/>
+        <source>Copy</source>
+        <translation>Másolás</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="838"/>
+        <source>Save</source>
+        <translation>Mentés</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="843"/>
+        <source>Exit</source>
+        <translation>Kilépés</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="854"/>
+        <source>Default</source>
+        <translation>Alapértelmezett</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="862"/>
+        <source>Peak Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="870"/>
+        <source>Real World Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="878"/>
+        <source>Default [+Mix]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="886"/>
+        <source>Peak Performance [+Mix]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="894"/>
+        <source>Real World Performance [+Mix]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.ui" line="905"/>
+        <source>Flush Pagecache</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="54"/>
+        <source>The device is encrypted. Performance may drop.</source>
+        <translation>A kötet titkosított. A mérés némileg pontatlan lehet.</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="253"/>
+        <location filename="../../src/mainwindow.cpp" line="374"/>
+        <source>MiB</source>
+        <translation>MiB</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="257"/>
+        <location filename="../../src/mainwindow.cpp" line="374"/>
+        <source>GiB</source>
+        <translation>GiB</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="295"/>
+        <location filename="../../src/mainwindow.cpp" line="301"/>
+        <source>&lt;h2&gt;Sequential %1 MiB&lt;br/&gt;Queues=%2&lt;br/&gt;Threads=%3&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Folyamatos %1 MiB&lt;br/&gt;Sorozatok=%2&lt;br/&gt;Szálak=%3&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="307"/>
+        <location filename="../../src/mainwindow.cpp" line="313"/>
+        <source>&lt;h2&gt;Random %1 KiB&lt;br/&gt;Queues=%2&lt;br/&gt;Threads=%3&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Véletlenszerű %1 KiB&lt;br/&gt;Sorozatok=%2&lt;br/&gt;Szálak=%3&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="318"/>
+        <source>&lt;h2&gt;Sequential %1 MiB&lt;br/&gt;Queues=%2&lt;br/&gt;Threads=%3&lt;br/&gt;(%4)&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Folyamatos %1 MiB&lt;br/&gt;Sorozatok=%2&lt;br/&gt;Szálak=%3&lt;br/&gt;(%4)&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="324"/>
+        <location filename="../../src/mainwindow.cpp" line="328"/>
+        <location filename="../../src/mainwindow.cpp" line="332"/>
+        <source>&lt;h2&gt;Random %1 KiB&lt;br/&gt;Queues=%2&lt;br/&gt;Threads=%3&lt;br/&gt;(%4)&lt;/h2&gt;</source>
+        <translation>&lt;h2&gt;Véletlenszerű %1 KiB&lt;br/&gt;Sorozatok=%2&lt;br/&gt;Szálak=%3&lt;br/&gt;(%4)&lt;/h2&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="374"/>
+        <source>Bytes</source>
+        <translation>bájt</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="374"/>
+        <source>KiB</source>
+        <translation>KiB</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="374"/>
+        <source>TiB</source>
+        <translation>TiB</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="374"/>
+        <source>PiB</source>
+        <translation>PiB</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="564"/>
+        <source>Bad Directory</source>
+        <translation>Nem megfelelő könyvtár</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="564"/>
+        <source>The directory is not writable.</source>
+        <translation>A könyvtár tartalma nem írható.</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="639"/>
+        <location filename="../../src/mainwindow.cpp" line="640"/>
+        <location filename="../../src/mainwindow.cpp" line="641"/>
+        <location filename="../../src/mainwindow.cpp" line="642"/>
+        <location filename="../../src/mainwindow.cpp" line="643"/>
+        <source>Stop</source>
+        <translation>Megszakítás</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="685"/>
+        <source>Stopping...</source>
+        <translation>Megszakítás...</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="689"/>
+        <source>Not available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="689"/>
+        <source>Directory is not specified.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="692"/>
+        <source>Confirmation</source>
+        <translation>Jóváhagyás</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="693"/>
+        <source>This action destroys the data in %1
+Do you want to continue?</source>
+        <translation>A művelet adathalmazt fog létrehozni a(z) %1 fájlban.
+Folytatod?</translation>
+    </message>
+    <message>
+        <location filename="../../src/mainwindow.cpp" line="707"/>
+        <source>Benchmark Failed</source>
+        <translation>Mérés sikertelen</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../../src/global.cpp" line="13"/>
+        <source>&lt;h1&gt;%1 MB/s&lt;br/&gt;%2 GB/s&lt;br/&gt;%3 IOPS&lt;br/&gt;%4 μs&lt;/h1&gt;</source>
+        <translation>&lt;h1&gt;%1 MB/mp&lt;br/&gt;%2 GB/mp&lt;br/&gt;%3 IOPS&lt;br/&gt;%4 μs&lt;/h1&gt;</translation>
+    </message>
+    <message>
+        <location filename="../../src/main.cpp" line="35"/>
+        <source>KDiskMark is not running as root.
+Clearing the I/O cache will not be performed.
+Not clearing the cache may cause incorrect performance measurement, namely unreal high speed, while reading.
+This is especially important if you are going to benchmark external devices.</source>
+        <translation>A KDiskMark nem rendszergazdaként fut.
+A műveleti gyorsítótár így nem törölhető.
+A műveleti gyorsítótár megtartása pontatlan mérést eredményezhet.
+Ez különösen előnytelen lehet, ha a mérni kívánt lemez külső lemez.</translation>
+    </message>
+    <message>
+        <location filename="../../src/main.cpp" line="49"/>
+        <source>No FIO was found. Please install FIO before using KDiskMark.</source>
+        <translation>Nincs telepítve FIO csomag a rendszerben. Kérlek, telepítsd a KDiskMark használata előtt!</translation>
+    </message>
+</context>
+<context>
+    <name>Settings</name>
+    <message>
+        <location filename="../../src/settings.ui" line="14"/>
+        <source>Settings</source>
+        <translation>Beállítások</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="29"/>
+        <source>Sequential (1)</source>
+        <translation>Folyamatos (1)</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="85"/>
+        <source>Sequential (2)</source>
+        <translation>Folyamatos (2)</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="151"/>
+        <source>Random (1)</source>
+        <translation>Véletlenszerű (1)</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="167"/>
+        <source>Random (2)</source>
+        <translation>Véletlenszerű (2)</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="213"/>
+        <source>Block Size</source>
+        <translation>Adath. mérete</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="229"/>
+        <source>Queues</source>
+        <translation>Sorozat</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="245"/>
+        <source>Threads</source>
+        <translation>Szálak</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="280"/>
+        <source>Measuring time</source>
+        <translation>Mérések száma</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.ui" line="306"/>
+        <source>Interval time</source>
+        <translation>Szünet hossza</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.cpp" line="21"/>
+        <location filename="../../src/settings.cpp" line="26"/>
+        <source>sec</source>
+        <translation>mp</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.cpp" line="22"/>
+        <location filename="../../src/settings.cpp" line="27"/>
+        <source>min</source>
+        <translation>p</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.cpp" line="37"/>
+        <location filename="../../src/settings.cpp" line="38"/>
+        <source>MiB</source>
+        <translation>MiB</translation>
+    </message>
+    <message>
+        <location filename="../../src/settings.cpp" line="51"/>
+        <location filename="../../src/settings.cpp" line="52"/>
+        <source>KiB</source>
+        <translation>KiB</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Not complete yet but mostly done. I have to mention that `hu_HU` ISO code can be set, but in general Hungarian has no variants. That's why I used only `hu`. The program instantly detected it with this code while I tested.