### PR TITLE
docs: update Arch documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ sudo apt install kdiskmark
 
 ### Arch based distros
 
-KDiskMark is included in the official [community](https://www.archlinux.org/packages/community/x86_64/kdiskmark/) repo. You can install it like any other package:
+KDiskMark is included in the official [extra](https://www.archlinux.org/packages/extra/x86_64/kdiskmark/) repo. You can install it like any other package:
 ```bash
 sudo pacman -Syu kdiskmark
 ```


### PR DESCRIPTION
Arch Linux [migrated its packaging to Gitlab](https://archlinux.org/news/git-migration-announcement/) in March of this year. During this process the `[community]` repo was merged into `[extra]`. If you try to open the old link it will result in an 404 error.