### PR TITLE
Add icons to menu items

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -59,6 +59,18 @@ MainWindow::MainWindow(QWidget *parent)
 
     ui->comboBox_Storages->setItemDelegate(new StorageItemDelegate());
 
+    ui->actionCopy->setIcon(QIcon::fromTheme("edit-copy"));
+    ui->actionSave->setIcon(QIcon::fromTheme("document-save"));
+    ui->actionExit->setIcon(QIcon::fromTheme("application-exit"));
+    ui->menuTest_Data->setIcon(QIcon::fromTheme("distribute-randomize"));
+    ui->actionQueues_Threads->setIcon(QIcon::fromTheme("configure"));
+    ui->actionTheme_Use_Fusion->setIcon(QIcon::fromTheme("preferences-desktop-color"));
+    ui->actionTheme_Stylesheet_Light->setIcon(QIcon::fromTheme("color-picker-white"));
+    ui->actionTheme_Stylesheet_Dark->setIcon(QIcon::fromTheme("color-picker-black"));
+    ui->actionTheme_Do_not_apply->setIcon(QIcon::fromTheme("edit-undo"));
+    ui->actionAbout->setIcon(QIcon::fromTheme("kdiskmark"));
+    ui->menuLanguage->setIcon(QIcon::fromTheme("language-chooser"));
+
     ui->actionDefault->setProperty("profile", Global::PerformanceProfile::Default);
     ui->actionDefault->setProperty("mixed", false);
     ui->actionPeak_Performance->setProperty("profile", Global::PerformanceProfile::Peak);


### PR DESCRIPTION
Adds icons to menu items where it makes sense:
- Copy
- Save
- Exit
- Test Data
- Queues & Threads
- Use Fusion
- Stylesheet Light
- Stylesheet Dark
- Do not apply
- About Kdiskmark
- Language

Example screenshot:
![Screenshot_20240106_105535](https://github.com/JonMagon/KDiskMark/assets/43704682/069ad3d8-16da-41ff-ab3c-508b4bdb42d4)
