### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/src/diskdriveinfo.cpp
+++ b/src/diskdriveinfo.cpp
@@ -18,11 +18,11 @@ QString DiskDriveInfo::getDeviceByVolume(const QString &volume)
 QString DiskDriveInfo::getModelName(const QString &volume)
 {
 #if defined(__linux__)
-    QFileInfo sysClass(QFileInfo(QString("/sys/class/block/%1/..")
+    QFileInfo sysClass(QFileInfo(QStringLiteral("/sys/class/block/%1/..")
                                  .arg(getDeviceByVolume(volume)))
                        .canonicalFilePath());
 
-    QFile sysBlock(QString("/sys/block/%1/device/model").arg(sysClass.baseName()));
+    QFile sysBlock(QStringLiteral("/sys/block/%1/device/model").arg(sysClass.baseName()));
 
     if (!sysBlock.open(QIODevice::ReadOnly | QIODevice::Text))
         return QString();
@@ -56,7 +56,7 @@ bool DiskDriveInfo::isEncrypted(const QString &volume)
     if (device.indexOf("dm") != 0)
         return false;
 
-    QFile sysBlock(QString("/sys/block/%1/dm/uuid").arg(device));
+    QFile sysBlock(QStringLiteral("/sys/block/%1/dm/uuid").arg(device));
 
     if (!sysBlock.open(QIODevice::ReadOnly | QIODevice::Text))
         return false;

--- a/src/helper.cpp
+++ b/src/helper.cpp
@@ -167,7 +167,7 @@ QVariantMap Helper::prepareBenchmarkFile(const QString &benchmarkPath, int fileS
     m_benchmarkFile.setFileTemplate(QStringLiteral("%1/%2").arg(benchmarkPath).arg("kdiskmark-XXXXXX.tmp"));
 
     if (!m_benchmarkFile.open()) {
-        return {{"success", false}, {"error", QString("An error occurred while creating the benchmark file: %1").arg(m_benchmarkFile.errorString())}};
+        return {{"success", false}, {"error", QStringLiteral("An error occurred while creating the benchmark file: %1").arg(m_benchmarkFile.errorString())}};
     }
 
     m_process = new QProcess();

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -38,7 +38,7 @@ MainWindow::MainWindow(QWidget *parent)
 
     for (const QLocale &locale : locales) {
         QString langName = locale.nativeLanguageName();
-        QAction *lang = new QAction(QString("%1%2").arg(langName[0].toUpper(), langName.mid(1)), this);
+        QAction *lang = new QAction(QStringLiteral("%1%2").arg(langName[0].toUpper(), langName.mid(1)), this);
         lang->setIcon(QIcon(QStringLiteral(":/icons/flags/%1.svg").arg(locale.name().mid(3))));
         lang->setCheckable(true);
         lang->setData(locale);
@@ -519,7 +519,7 @@ QString MainWindow::formatSize(quint64 available, quint64 total)
         outputTotal = outputTotal / 1024;
     }
     QLocale locale = QLocale();
-    return QString("%1/%2 %3").arg(locale.toString(outputAvailable, 'f', 2))
+    return QStringLiteral("%1/%2 %3").arg(locale.toString(outputAvailable, 'f', 2))
             .arg(locale.toString(outputTotal, 'f', 2)).arg(units[i]);
 }
 
@@ -552,7 +552,7 @@ QString MainWindow::combineOutputTestResult(const QProgressBar *progressBar, con
 {
     QMetaEnum metaEnum = QMetaEnum::fromType<Global::ComparisonUnit>();
 
-    return QString("%1 %2 %3 (Q=%4, T=%5): %6 MB/s [ %7 IOPS] < %8 us>")
+    return QStringLiteral("%1 %2 %3 (Q=%4, T=%5): %6 MB/s [ %7 IOPS] < %8 us>")
            .arg(params.Pattern == Global::BenchmarkIOPattern::SEQ ? "Sequential" : "Random")
            .arg(QString::number(params.BlockSize >= 1024 ? params.BlockSize / 1024 : params.BlockSize).rightJustified(3, ' '))
            .arg(params.BlockSize >= 1024 ? "MiB" : "KiB")
@@ -576,13 +576,13 @@ QString MainWindow::getTextBenchmarkResult()
 
     QStringList output;
 
-    output << QString("KDiskMark (%1): https://github.com/JonMagon/KDiskMark")
+    output << QStringLiteral("KDiskMark (%1): https://github.com/JonMagon/KDiskMark")
               .arg(qApp->applicationVersion())
               .rightJustified(Global::getOutputColumnsCount(), ' ')
-           << QString("Flexible I/O Tester (%1): https://github.com/axboe/fio")
+           << QStringLiteral("Flexible I/O Tester (%1): https://github.com/axboe/fio")
               .arg(m_benchmark->getFIOVersion())
               .rightJustified(Global::getOutputColumnsCount(), ' ')
-           << QString("-").repeated(Global::getOutputColumnsCount())
+           << QStringLiteral("-").repeated(Global::getOutputColumnsCount())
            << "* MB/s = 1,000,000 bytes/s [SATA/600 = 600,000,000 bytes/s]"
            << "* KB = 1000 bytes, KiB = 1024 bytes";
 
@@ -616,7 +616,7 @@ QString MainWindow::getTextBenchmarkResult()
 
     if (settings.getMixedState() && settings.getPerformanceProfile() != Global::PerformanceProfile::Demo) {
          output << QString()
-                << QString("[Mix] Read %1%/Write %2%")
+                << QStringLiteral("[Mix] Read %1%/Write %2%")
                    .arg(settings.getRandomReadPercentage())
                    .arg(100 - settings.getRandomReadPercentage())
                 << combineOutputTestResult(ui->mixBar_1, settings.getBenchmarkParams(Global::BenchmarkTest::Test_1, settings.getPerformanceProfile()))
@@ -630,9 +630,9 @@ QString MainWindow::getTextBenchmarkResult()
     QString profiles[] = { "Default", "Peak Performance", "Real World Performance", "Demo" };
 
     output << QString()
-           << QString("Profile: %1%2")
+           << QStringLiteral("Profile: %1%2")
               .arg(profiles[(int)settings.getPerformanceProfile()]).arg(settings.getMixedState() ? " [+Mix]" : QString())
-           << QString("   Test: %1")
+           << QStringLiteral("   Test: %1")
               .arg("%1 %2 (x%3) [Measure: %4 %5 / Interval: %6 %7]")
               .arg(settings.getFileSize() >= 1024 ? settings.getFileSize() / 1024 : settings.getFileSize())
               .arg(settings.getFileSize() >= 1024 ? "GiB" : "MiB")
@@ -641,10 +641,10 @@ QString MainWindow::getTextBenchmarkResult()
               .arg(settings.getMeasuringTime() >= 60 ? "min" : "sec")
               .arg(settings.getIntervalTime() >= 60 ? settings.getIntervalTime() / 60 : settings.getIntervalTime())
               .arg(settings.getIntervalTime() >= 60 ? "min" : "sec")
-           << QString("   Date: %1 %2")
+           << QStringLiteral("   Date: %1 %2")
               .arg(QDate::currentDate().toString("yyyy-MM-dd"))
               .arg(QTime::currentTime().toString("hh:mm:ss"))
-           << QString("     OS: %1 %2 [%3 %4]").arg(QSysInfo::productType()).arg(QSysInfo::productVersion())
+           << QStringLiteral("     OS: %1 %2 [%3 %4]").arg(QSysInfo::productType()).arg(QSysInfo::productVersion())
               .arg(QSysInfo::kernelType()).arg(QSysInfo::kernelVersion());
 
     return output.join("\n");
@@ -949,7 +949,7 @@ void MainWindow::benchmarkFailed(const QString &error)
 
 void MainWindow::benchmarkStatusUpdate(const QString &name)
 {
-    setWindowTitle(QString("%1 - %2").arg(m_windowTitle, name));
+    setWindowTitle(QStringLiteral("%1 - %2").arg(m_windowTitle, name));
 }
 
 void MainWindow::handleResults(QProgressBar *progressBar, const Benchmark::PerformanceResult &result)

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -15,13 +15,13 @@ Settings::Settings(QWidget *parent) :
     ui->buttonBox->addButton(QStringLiteral("NVMe SSD"), QDialogButtonBox::ActionRole);
 
     for (int val : { 0, 1, 3, 5, 10, 30, 60, 180, 300, 600 }) {
-        ui->IntervalTime->addItem(val < 60 ? QString("%1 %2").arg(val).arg(tr("sec"))
-                                           : QString("%1 %2").arg(val / 60).arg(tr("min")), val);
+        ui->IntervalTime->addItem(val < 60 ? QStringLiteral("%1 %2").arg(val).arg(tr("sec"))
+                                           : QStringLiteral("%1 %2").arg(val / 60).arg(tr("min")), val);
     }
 
     for (int val : { 5, 10, 20, 30, 60 }) {
-        ui->MeasuringTime->addItem(val < 60 ? QString("%1 %2").arg(val).arg(tr("sec"))
-                                            : QString("%1 %2").arg(val / 60).arg(tr("min")), val);
+        ui->MeasuringTime->addItem(val < 60 ? QStringLiteral("%1 %2").arg(val).arg(tr("sec"))
+                                            : QStringLiteral("%1 %2").arg(val / 60).arg(tr("min")), val);
     }
 
     for (const Global::BenchmarkIOPattern &pattern : { Global::BenchmarkIOPattern::SEQ, Global::BenchmarkIOPattern::RND }) {


### PR DESCRIPTION
Qt provides a macro `QStringLiteral()`, which makes constructing QString objects from string literals more efficient.