### PR TITLE
GUI: RAID controller labels + uniform, non-clipping result font

### DIFF
--- a/src/diskdriveinfo.cpp
+++ b/src/diskdriveinfo.cpp
@@ -3,10 +3,132 @@
 #include <QString>
 #include <QFile>
 #include <QFileInfo>
+#if defined(__linux__)
+// cppcheck-suppress missingIncludeSystem ; Qt's headers live outside cppcheck's search path
+#include <QDir>
+#endif
 #ifdef __FreeBSD__
 #include <sys/disk.h>
 #include <sys/fcntl.h>
 #include <unistd.h>
+#endif
+
+#if defined(__linux__)
+namespace {
+
+// Resolve a PCI vendor:device pair to a human-readable "ShortVendor DeviceName"
+// (e.g. 0x1022:0xb000 -> "AMD RAID Bottom Device") using the system hwids
+// database shipped by the "hwdata"/"pciutils" packages. The vendor's short name
+// is taken from the trailing "[...]" alias when present, so we get "AMD" rather
+// than the verbose "Advanced Micro Devices, Inc. [AMD]". Returns an empty string
+// if the database is missing or the ids are not listed.
+QString pciDeviceName(quint16 vendorId, quint16 deviceId)
+{
+    static const QStringList paths = {
+        QStringLiteral("/usr/share/hwdata/pci.ids"),
+        QStringLiteral("/usr/share/misc/pci.ids"),
+    };
+
+    const QString vendorPrefix = QStringLiteral("%1  ").arg(vendorId, 4, 16, QLatin1Char('0'));
+    const QString devicePrefix = QStringLiteral("%1  ").arg(deviceId, 4, 16, QLatin1Char('0'));
+
+    for (const QString &path : paths) {
+        QFile file(path);
+        if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+            continue;
+
+        QString shortVendor;
+        bool inVendor = false;
+
+        while (!file.atEnd()) {
+            // Read one line, dropping the trailing newline but keeping the leading
+            // tabs that distinguish vendor / device / subsystem entries.
+            QString line = QString::fromUtf8(file.readLine());
+            while (line.endsWith(QLatin1Char('\n')) || line.endsWith(QLatin1Char('\r')))
+                line.chop(1);
+            if (line.isEmpty() || line.startsWith(QLatin1Char('#')))
+                continue;
+
+            if (!line.startsWith(QLatin1Char('\t'))) {
+                // Vendor line, e.g. "1022  Advanced Micro Devices, Inc. [AMD]".
+                // The list is sorted by vendor id, so once we leave our vendor's
+                // block the device cannot appear later: stop scanning.
+                if (inVendor)
+                    return QString();
+                if (line.startsWith(vendorPrefix)) {
+                    inVendor = true;
+                    const QString vendorName = line.mid(vendorPrefix.length()).trimmed();
+                    const int lb = vendorName.lastIndexOf(QLatin1Char('['));
+                    const int rb = vendorName.lastIndexOf(QLatin1Char(']'));
+                    shortVendor = (lb >= 0 && rb > lb)
+                            ? vendorName.mid(lb + 1, rb - lb - 1)
+                            : vendorName;
+                }
+            } else if (inVendor && !line.startsWith(QStringLiteral("\t\t"))) {
+                // Device line, e.g. "\tb000  RAID Bottom Device" (two-tab lines
+                // are subsystem entries and are skipped by the check above).
+                const QString device = line.mid(1);
+                if (device.startsWith(devicePrefix)) {
+                    const QString deviceName = device.mid(devicePrefix.length()).trimmed();
+                    return shortVendor.isEmpty()
+                            ? deviceName
+                            : shortVendor + QLatin1Char(' ') + deviceName;
+                }
+            }
+        }
+        return QString();
+    }
+
+    return QString();
+}
+
+// Read a "0x1234"-style hex id from a sysfs attribute. Returns 0 on failure.
+quint16 readSysfsHex(const QString &path)
+{
+    QFile file(path);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+        return 0;
+    return file.readAll().simplified().toUShort(nullptr, 16);
+}
+
+// Firmware/driver-backed RAID (e.g. AMD RAIDXpert2) exposes a single virtual
+// array block device with no link back to the controllers that make it up. Find
+// the RAID controller among the PCI devices and return its human name, e.g.
+// "AMD RAID Bottom Device". Returns an empty string if none is identified.
+QString firmwareRaidControllerName()
+{
+    QDir pciDir(QStringLiteral("/sys/bus/pci/devices"));
+    const auto slotDirs = pciDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QString &slot : slotDirs) {
+        const QString base = pciDir.filePath(slot);
+
+        QString driver = QFileInfo(base + QStringLiteral("/driver")).symLinkTarget();
+        driver = driver.mid(driver.lastIndexOf(QLatin1Char('/')) + 1);
+
+        // Accept either a known firmware-RAID member driver, or the generic PCI
+        // "RAID bus controller" class (0x0104xx) used by other RAID HBAs.
+        QFile classFile(base + QStringLiteral("/class"));
+        QString pciClass;
+        if (classFile.open(QIODevice::ReadOnly | QIODevice::Text))
+            pciClass = classFile.readAll().simplified();
+
+        // Known firmware-RAID member drivers (AMD RAIDXpert2).
+        const bool isRaidDriver = driver == QLatin1String("rcbottom")
+                               || driver == QLatin1String("rcraid");
+        if (!isRaidDriver && !pciClass.startsWith(QStringLiteral("0x0104")))
+            continue;
+
+        const quint16 vendorId = readSysfsHex(base + QStringLiteral("/vendor"));
+        const quint16 deviceId = readSysfsHex(base + QStringLiteral("/device"));
+        const QString name = pciDeviceName(vendorId, deviceId);
+        if (!name.isEmpty())
+            return name;
+    }
+
+    return QString();
+}
+
+} // namespace
 #endif
 
 QString DiskDriveInfo::getDeviceByVolume(const QString &volume)
@@ -22,14 +144,32 @@ QString DiskDriveInfo::getModelName(const QString &volume)
                                  .arg(getDeviceByVolume(volume)))
                        .canonicalFilePath());
 
-    QFile sysBlock(QStringLiteral("/sys/block/%1/device/model").arg(sysClass.baseName()));
+    const QString blockName = sysClass.baseName();
 
-    if (!sysBlock.open(QIODevice::ReadOnly | QIODevice::Text))
-        return QString();
+    QFile sysBlock(QStringLiteral("/sys/block/%1/device/model").arg(blockName));
 
-    QString model(sysBlock.readAll().simplified());
+    if (sysBlock.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QString model(sysBlock.readAll().simplified());
+        sysBlock.close();
+        if (!model.isEmpty())
+            return model;
+    }
 
-    sysBlock.close();
+    // RAID arrays and other virtual devices have no device/model node, which would
+    // otherwise leave the field blank. Provide a descriptive fallback instead.
+
+    // Firmware/driver-backed RAID (e.g. AMD RAIDXpert2 "rcraid", Intel RST "isw")
+    // presents a single virtual array device and hides its members. Name the
+    // controller from the PCI database when we can, e.g.
+    // "RAID Array: AMD RAID Bottom Device", otherwise a plain "RAID Array".
+    if (blockName.contains(QStringLiteral("raid"), Qt::CaseInsensitive)) {
+        const QString controller = firmwareRaidControllerName();
+        return controller.isEmpty()
+                ? QStringLiteral("RAID Array")
+                : QStringLiteral("RAID Array: %1").arg(controller);
+    }
+
+    return QString();
 #elif defined(__FreeBSD__)
     struct diocgattr_arg arg;
 
@@ -43,9 +183,13 @@ QString DiskDriveInfo::getModelName(const QString &volume)
     QString model(arg.value.str);
 
     close(fd);
-#endif
 
     return model;
+#else
+    Q_UNUSED(volume)
+#endif
+
+    return QString();
 }
 
 

--- a/src/global.cpp
+++ b/src/global.cpp
@@ -47,7 +47,10 @@ QString Global::getToolTipTemplate()
 
 QString Global::getComparisonLabelTemplate()
 {
-    return QStringLiteral("<p align=\"center\">%1 [%2]</p>");
+    // Plain text (not <p> rich text): the labels are already centre-aligned in the .ui,
+    // and a <p> element's DPI-scaled top/bottom margins would clip the text vertically
+    // inside its fixed-height row on high-DPI displays.
+    return QStringLiteral("%1 [%2]");
 }
 
 QString Global::getRWSequentialRead()

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -512,6 +512,8 @@ void MainWindow::refreshProgressBars()
                         )
                     );
     }
+
+    applyUniformProgressBarFont();
 }
 
 QString MainWindow::formatSize(quint64 available, quint64 total)
@@ -1050,6 +1052,95 @@ void MainWindow::updateProgressBar(QProgressBar *progressBar)
         else {
             progressBar->setValue(score <= 0.1 ? 0 : 16.666666666666 * log10(score * 10));
         }
+    }
+
+    applyUniformProgressBarFont();
+}
+
+qreal MainWindow::fitProgressBarPointSize(QProgressBar *progressBar)
+{
+    // The result font is authored at a fixed point size in mainwindow.ui, while the
+    // bars have a fixed pixel width. Point sizes scale with the screen DPI, so on
+    // high-DPI displays (e.g. after a driver reports the panel's real DPI) or with
+    // long/localized numbers the text overflows the box and gets clipped. Return the
+    // largest point size (<= the authored size) at which the current text still fits.
+    QVariant baseSize = progressBar->property("baseFontPointSizeF");
+    if (!baseSize.isValid()) {
+        baseSize = progressBar->font().pointSizeF();
+        progressBar->setProperty("baseFontPointSizeF", baseSize);
+    }
+
+    const qreal basePointSize = baseSize.toReal();
+    if (basePointSize <= 0.0)
+        return basePointSize;
+
+    // Available text width. Fall back to the fixed minimum width so the fit is correct
+    // even before the window is first laid out (the result bars have min == max width).
+    // A QProgressBar's actual text-drawing region is noticeably narrower than its raw
+    // width, so subtracting only the frame lets long numbers still clip on high-DPI
+    // displays. Leave a comfortable margin on each side (~8% of the box, at least 12px)
+    // so the value sits inside the box with breathing room, like the reference layout.
+    const int barWidth = qMax(progressBar->width(), progressBar->minimumWidth());
+    const int frame = progressBar->style()->pixelMetric(QStyle::PM_DefaultFrameWidth, nullptr, progressBar);
+    const int margin = frame + qMax(12, qRound(barWidth * 0.08));
+    const int available = barWidth - 2 * margin;
+    if (available <= 0)
+        return basePointSize;
+
+    // Size against a representative worst-case value, not just the current text. The
+    // startup placeholder ("0.00") and other short values would otherwise fit at the
+    // full authored size and render oversized, then snap smaller once real numbers
+    // arrive. Measuring the widest realistic value keeps the size uniform and stable
+    // from the first frame while still never clipping. Fall back to the current text
+    // if it is somehow wider (locale grouping, unexpected magnitudes).
+    const QString sample = QLocale().toString(999999.99, 'f', 2);
+    const QString text = progressBar->format().size() > sample.size()
+                             ? progressBar->format()
+                             : sample;
+
+    QFont font = progressBar->font();
+    qreal pointSize = basePointSize;
+    font.setPointSizeF(pointSize);
+
+    auto textWidth = [&text](const QFont &f) {
+#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
+        return QFontMetrics(f).horizontalAdvance(text);
+#else
+        return QFontMetrics(f).width(text);
+#endif
+    };
+
+    while (pointSize > 6.0 && textWidth(font) > available) {
+        pointSize -= 0.5;
+        font.setPointSizeF(pointSize);
+    }
+
+    return pointSize;
+}
+
+void MainWindow::applyUniformProgressBarFont()
+{
+    // Keep every result field at a single, consistent font size (like the reference
+    // layout) instead of shrinking each box independently. Use the smallest size any
+    // currently shown bar needs to fit its value, then apply it to all of them.
+    qreal pointSize = -1.0;
+    for (auto const& progressBar: m_progressBars) {
+        if (progressBar->isHidden())
+            continue;
+        const qreal fitted = fitProgressBarPointSize(progressBar);
+        if (fitted > 0.0 && (pointSize < 0.0 || fitted < pointSize))
+            pointSize = fitted;
+    }
+
+    if (pointSize <= 0.0)
+        return;
+
+    for (auto const& progressBar: m_progressBars) {
+        if (qFuzzyCompare(progressBar->font().pointSizeF(), pointSize))
+            continue;
+        QFont font = progressBar->font();
+        font.setPointSizeF(pointSize);
+        progressBar->setFont(font);
     }
 }
 

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -78,6 +78,8 @@ private:
     void updatePresetsSelection();
     void refreshProgressBars();
     void updateProgressBar(QProgressBar *progressBar);
+    qreal fitProgressBarPointSize(QProgressBar *progressBar);
+    void applyUniformProgressBarFont();
     void updateLabels();
     bool runCombinedRandomTest();
     QString combineOutputTestResult(const QProgressBar *progressBar, const Global::BenchmarkParams &params);


### PR DESCRIPTION
## Summary

Two GUI improvements, combined into one branch:

**1. Show RAID controller name for firmware-RAID arrays**

Firmware/driver-backed RAID (e.g. AMD RAIDXpert2 `rcraid`) exposes a single virtual array block device with no device/model node and no link back to its member controllers, so the disk-type label was left blank.

This detects that case and names the controller from the system PCI id database — producing e.g. **"RAID Array: AMD RAID Bottom Device"**, with a plain **"RAID Array"** fallback when the database is missing or the ids aren't listed.

**2. Keep result fields at a uniform, non-clipping font size**

Point-size result fonts scale with screen DPI, so on high-DPI displays (or with long/localized numbers) the values overflowed their fixed-width bars and clipped. This:

- fits the largest point size at which the value still fits, sized against a representative worst-case number so the size is **stable from the first frame** — the startup `0.00` no longer renders oversized and then snaps smaller once results arrive;
- applies the smallest size any visible bar needs to **all** of them, so every field stays uniform;
- drops the `<p>` wrapper whose DPI-scaled margins clipped text vertically.

## Changes

| File | What |
|---|---|
| `src/diskdriveinfo.cpp` | Firmware-RAID detection + PCI-id controller naming |
| `src/mainwindow.cpp` / `src/mainwindow.h` | Uniform result-font fitting |
| `src/global.cpp` | Plain-text comparison label template (drop `<p>` wrapper) |

## Testing

Built and launched locally (Qt, Linux/X11). Verified the app starts and the result fields render at a consistent, non-clipping size from startup.

<img width="701" height="610" alt="Screenshot_20260709_114506" src="https://github.com/user-attachments/assets/60cc8391-08f1-41e6-96b4-687cc8144d3a" />
