### PR TITLE
Set window icon for the application

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,6 +36,7 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationVersion(QStringLiteral("%1.%2.%3").arg(PROJECT_VERSION_MAJOR)
                                             .arg(PROJECT_VERSION_MINOR).arg(PROJECT_VERSION_PATCH));
     QCoreApplication::setOrganizationName(QStringLiteral(PROJECT_NAME));
+    QGuiApplication::setWindowIcon(QIcon::fromTheme(QStringLiteral(PROJECT_NAME)));
 
     const bool noDisplay = qEnvironmentVariableIsEmpty("DISPLAY")
                         && qEnvironmentVariableIsEmpty("WAYLAND_DISPLAY");


### PR DESCRIPTION
The window icon is commonly used by window managers and taskbars on X11.